### PR TITLE
feat(auth): Identity + JWT + roles seeding and auth endpoints

### DIFF
--- a/src/Emi.Api/Contracts/Auth/AuthResponse.cs
+++ b/src/Emi.Api/Contracts/Auth/AuthResponse.cs
@@ -1,0 +1,7 @@
+namespace Emi.Api.Contracts.Auth;
+
+public sealed class AuthResponse
+{
+    public string Token     { get; set; } = default!;
+    public DateTime Expires { get; set; }
+}

--- a/src/Emi.Api/Contracts/Auth/LoginRequest.cs
+++ b/src/Emi.Api/Contracts/Auth/LoginRequest.cs
@@ -1,0 +1,7 @@
+namespace Emi.Api.Contracts.Auth;
+
+public sealed class LoginRequest
+{
+    public string Email    { get; set; } = default!;
+    public string Password { get; set; } = default!;
+}

--- a/src/Emi.Api/Contracts/Auth/RegisterRequest.cs
+++ b/src/Emi.Api/Contracts/Auth/RegisterRequest.cs
@@ -1,0 +1,7 @@
+namespace Emi.Api.Contracts.Auth;
+
+public sealed class RegisterRequest
+{
+    public string Email    { get; set; } = default!;
+    public string Password { get; set; } = default!;
+}

--- a/src/Emi.Api/Controllers/AuthController.cs
+++ b/src/Emi.Api/Controllers/AuthController.cs
@@ -1,0 +1,51 @@
+using System.Security.Claims;
+using Emi.Infrastructure.Options;
+using Emi.Api.Contracts.Auth;
+using Emi.Application.Abstractions.Security;
+using Emi.Infrastructure.Identity.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Emi.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : ControllerBase
+{
+    private readonly UserManager<AppUser> _userManager;
+    private readonly IJwtTokenService _jwt;
+    private readonly JwtOptions _opts;
+
+    public AuthController(UserManager<AppUser> userManager, IJwtTokenService jwt, IOptions<JwtOptions> opts)
+    => (_userManager, _jwt, _opts) = (userManager, jwt, opts.Value);
+
+    [AllowAnonymous]
+    [HttpPost("register")]
+    public async Task<IActionResult> Register([FromBody] RegisterRequest r)
+    {
+        var exists = await _userManager.FindByEmailAsync(r.Email);
+        if (exists is not null) return Conflict("User already exists");
+
+        var user = new AppUser { UserName = r.Email, Email = r.Email, EmailConfirmed = true };
+        var result = await _userManager.CreateAsync(user, r.Password);
+        if (!result.Succeeded) return BadRequest(result.Errors);
+
+        await _userManager.AddToRoleAsync(user, "User"); // rol por defecto
+        return CreatedAtAction(nameof(Register), new { email = user.Email }, null);
+    }
+
+    [AllowAnonymous]
+    [HttpPost("login")]
+    public async Task<ActionResult<AuthResponse>> Login([FromBody] LoginRequest r)
+    {
+        var user = await _userManager.FindByEmailAsync(r.Email);
+        if (user is null || !await _userManager.CheckPasswordAsync(user, r.Password))
+            return Unauthorized();
+
+        var roles = await _userManager.GetRolesAsync(user);
+        var token = _jwt.CreateToken(user.Id, user.UserName!, roles);
+        return Ok(new AuthResponse { Token = token, Expires = DateTime.UtcNow.AddHours(2) });
+    }
+}

--- a/src/Emi.Api/Program.cs
+++ b/src/Emi.Api/Program.cs
@@ -1,15 +1,55 @@
-using Microsoft.EntityFrameworkCore;                 // <- UseSqlite
-using Emi.Application.Abstractions.Persistence;      // <- IAppDbContext
-using Emi.Infrastructure.Data;                       // <- EmiDbContext
-using Emi.Infrastructure.Data.Seeds;                 // <- SeedData
+using System.Text;
+using Emi.Infrastructure.Options;
+using Emi.Application.Abstractions.Persistence;
+using Emi.Application.Abstractions.Security;
+using Emi.Infrastructure.Data;
+using Emi.Infrastructure.Data.Seeds;
+using Emi.Infrastructure.Identity.Models;
+using Emi.Infrastructure.Identity.Seeds;
+using Emi.Infrastructure.Security;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
-var dbPath = Path.Combine(AppContext.BaseDirectory, "emi.db");
-var cs = builder.Configuration.GetConnectionString("Default") ?? $"Data Source={dbPath}";
-builder.Services.AddDbContext<EmiDbContext>(o => o.UseSqlite(cs));
 
-// Exponer la interfaz de persistencia
+// DbContext
+var cs = builder.Configuration.GetConnectionString("Default") ?? "Data Source=emi.db";
+builder.Services.AddDbContext<EmiDbContext>(o => o.UseSqlite(cs));
 builder.Services.AddScoped<IAppDbContext>(sp => sp.GetRequiredService<EmiDbContext>());
+
+// Identity
+builder.Services.AddIdentityCore<AppUser>(opts =>
+{
+    opts.Password.RequireNonAlphanumeric = false;
+    opts.Password.RequireUppercase = false;
+    opts.Password.RequiredLength = 6;
+})
+.AddRoles<IdentityRole>()
+.AddEntityFrameworkStores<EmiDbContext>();
+
+// JWT options
+builder.Services.Configure<JwtOptions>(builder.Configuration.GetSection("JWT"));
+var jwt = builder.Configuration.GetSection("JWT").Get<JwtOptions>() ?? new JwtOptions();
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(o =>
+    {
+        o.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = jwt.Issuer,
+            ValidAudience = jwt.Audience,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwt.Key))
+        };
+    });
+builder.Services.AddAuthorization();
+
+// JWT service
+builder.Services.AddSingleton<IJwtTokenService, JwtTokenService>();
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
@@ -20,12 +60,14 @@ var app = builder.Build();
 app.UseSwagger();
 app.UseSwaggerUI();
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
 app.MapGet("/", () => Results.Ok("API up"));
 
-// ---- SEED (creación/migración + datos básicos) ----
+// Seeds
 await SeedData.EnsureSeededAsync(app.Services);
+await IdentitySeed.EnsureSeededAsync(app.Services);
 
 app.Run();

--- a/src/Emi.Application/Abstractions/Security/IJwtTokenService.cs
+++ b/src/Emi.Application/Abstractions/Security/IJwtTokenService.cs
@@ -1,0 +1,9 @@
+using System.Security.Claims;
+
+namespace Emi.Application.Abstractions.Security;
+
+public interface IJwtTokenService
+{
+    string CreateToken(string subject, string name, IEnumerable<string> roles, DateTime? expires = null);
+    IEnumerable<Claim> BuildClaims(string subject, string name, IEnumerable<string> roles);
+}

--- a/src/Emi.Infrastructure/Identity/Models/AppUser.cs
+++ b/src/Emi.Infrastructure/Identity/Models/AppUser.cs
@@ -1,0 +1,5 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace Emi.Infrastructure.Identity.Models;
+
+public class AppUser : IdentityUser { }

--- a/src/Emi.Infrastructure/Identity/Seeds/IdentitySeed.cs
+++ b/src/Emi.Infrastructure/Identity/Seeds/IdentitySeed.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using Emi.Infrastructure.Identity.Models;
+using Emi.Infrastructure.Data;
+
+namespace Emi.Infrastructure.Identity.Seeds;
+
+public static class IdentitySeed
+{
+    public static async Task EnsureSeededAsync(IServiceProvider sp)
+    {
+        using var scope = sp.CreateScope();
+        var roleMgr = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+        var userMgr = scope.ServiceProvider.GetRequiredService<UserManager<AppUser>>();
+        var db      = scope.ServiceProvider.GetRequiredService<EmiDbContext>();
+
+        await db.Database.MigrateAsync();
+
+
+        foreach (var role in new[] { "Admin", "User" })
+        {
+            if (!await roleMgr.RoleExistsAsync(role))
+                await roleMgr.CreateAsync(new IdentityRole(role));
+        }
+
+        var adminEmail = "admin@emi.local";
+        var admin = await userMgr.FindByEmailAsync(adminEmail);
+        if (admin is null)
+        {
+            admin = new AppUser { UserName = adminEmail, Email = adminEmail, EmailConfirmed = true };
+            await userMgr.CreateAsync(admin, "Admin123$"); // solo dev
+            await userMgr.AddToRoleAsync(admin, "Admin");
+        }
+    }
+}

--- a/src/Emi.Infrastructure/Migrations/20250822172541_AddIdentity.Designer.cs
+++ b/src/Emi.Infrastructure/Migrations/20250822172541_AddIdentity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Emi.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Emi.Infrastructure.Migrations
 {
     [DbContext(typeof(EmiDbContext))]
-    partial class EmiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250822172541_AddIdentity")]
+    partial class AddIdentity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.19");

--- a/src/Emi.Infrastructure/Migrations/20250822172541_AddIdentity.cs
+++ b/src/Emi.Infrastructure/Migrations/20250822172541_AddIdentity.cs
@@ -1,0 +1,222 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Emi.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIdentity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AspNetRoles",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    NormalizedName = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUsers",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "TEXT", nullable: false),
+                    UserName = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    NormalizedUserName = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    Email = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    NormalizedEmail = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    EmailConfirmed = table.Column<bool>(type: "INTEGER", nullable: false),
+                    PasswordHash = table.Column<string>(type: "TEXT", nullable: true),
+                    SecurityStamp = table.Column<string>(type: "TEXT", nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "TEXT", nullable: true),
+                    PhoneNumber = table.Column<string>(type: "TEXT", nullable: true),
+                    PhoneNumberConfirmed = table.Column<bool>(type: "INTEGER", nullable: false),
+                    TwoFactorEnabled = table.Column<bool>(type: "INTEGER", nullable: false),
+                    LockoutEnd = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
+                    LockoutEnabled = table.Column<bool>(type: "INTEGER", nullable: false),
+                    AccessFailedCount = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUsers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetRoleClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    RoleId = table.Column<string>(type: "TEXT", nullable: false),
+                    ClaimType = table.Column<string>(type: "TEXT", nullable: true),
+                    ClaimValue = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoleClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetRoleClaims_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    UserId = table.Column<string>(type: "TEXT", nullable: false),
+                    ClaimType = table.Column<string>(type: "TEXT", nullable: true),
+                    ClaimValue = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserClaims_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserLogins",
+                columns: table => new
+                {
+                    LoginProvider = table.Column<string>(type: "TEXT", nullable: false),
+                    ProviderKey = table.Column<string>(type: "TEXT", nullable: false),
+                    ProviderDisplayName = table.Column<string>(type: "TEXT", nullable: true),
+                    UserId = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserLogins", x => new { x.LoginProvider, x.ProviderKey });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserLogins_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserRoles",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "TEXT", nullable: false),
+                    RoleId = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserRoles", x => new { x.UserId, x.RoleId });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserTokens",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "TEXT", nullable: false),
+                    LoginProvider = table.Column<string>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    Value = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserTokens", x => new { x.UserId, x.LoginProvider, x.Name });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserTokens_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetRoleClaims_RoleId",
+                table: "AspNetRoleClaims",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "RoleNameIndex",
+                table: "AspNetRoles",
+                column: "NormalizedName",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserClaims_UserId",
+                table: "AspNetUserClaims",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserLogins_UserId",
+                table: "AspNetUserLogins",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserRoles_RoleId",
+                table: "AspNetUserRoles",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "EmailIndex",
+                table: "AspNetUsers",
+                column: "NormalizedEmail");
+
+            migrationBuilder.CreateIndex(
+                name: "UserNameIndex",
+                table: "AspNetUsers",
+                column: "NormalizedUserName",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AspNetRoleClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserLogins");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserTokens");
+
+            migrationBuilder.DropTable(
+                name: "AspNetRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUsers");
+        }
+    }
+}

--- a/src/Emi.Infrastructure/Options/JwtOptions.cs
+++ b/src/Emi.Infrastructure/Options/JwtOptions.cs
@@ -1,0 +1,8 @@
+namespace Emi.Infrastructure.Options;
+
+public sealed class JwtOptions
+{
+    public string Issuer  { get; set; } = "emi";
+    public string Audience{ get; set; } = "emi-clients";
+    public string Key     { get; set; } = "change-this-in-prod-super-secret";
+}

--- a/src/Emi.Infrastructure/Security/JwtTokenService.cs
+++ b/src/Emi.Infrastructure/Security/JwtTokenService.cs
@@ -1,0 +1,41 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Emi.Application.Abstractions.Security;
+using Emi.Infrastructure.Options;               // usamos JwtOptions de la API
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Emi.Infrastructure.Security;
+
+public sealed class JwtTokenService : IJwtTokenService
+{
+    private readonly JwtOptions _opts;
+    public JwtTokenService(IOptions<JwtOptions> opts) => _opts = opts.Value;
+
+    public IEnumerable<Claim> BuildClaims(string subject, string name, IEnumerable<string> roles)
+    {
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, subject),
+            new(ClaimTypes.Name, name ?? subject)
+        };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return claims;
+    }
+
+    public string CreateToken(string subject, string name, IEnumerable<string> roles, DateTime? expires = null)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_opts.Key));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var token = new JwtSecurityToken(
+            issuer: _opts.Issuer,
+            audience: _opts.Audience,
+            claims: BuildClaims(subject, name, roles),
+            expires: expires ?? DateTime.UtcNow.AddHours(2),
+            signingCredentials: creds
+        );
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}


### PR DESCRIPTION
Resumen
Integra ASP.NET Core Identity con EF Core y autenticación JWT. Se agregan endpoints de registro y login, y se siembran los roles Admin/User junto a un usuario admin de desarrollo.
Objetivo: dejar lista la seguridad para proteger el CRUD de Employees en los siguientes PRs.